### PR TITLE
Zero out category score for showstopper rules (e.g. no-a11y-statement)

### DIFF
--- a/lib/score.js
+++ b/lib/score.js
@@ -1,16 +1,43 @@
 export class Score {
 
   constructor() {
+    // Regler som direkt sätter sin kategoripoäng till 0 ("showstoppers"),
+    // i stället för att gå genom det vanliga severity-avdraget.
+    //
+    // Används när en specifik regel innebär att kategorin är de facto
+    // underkänd — t.ex. när en lagstadgad tillgänglighetsredogörelse
+    // helt saknas. Lista bara regler där frånvaron är ett underkänt
+    // prov, inte saker som "delvis förenlig" eller liknande, för då
+    // tappar man nyans i poängsättningen.
+    //
+    // Vill man lägga till fler i framtiden (t.ex. om HTTPS helt saknas)
+    // är detta rätt ställe.
+    this.showstopperRules = new Set([
+      'no-a11y-statement'
+    ]);
   }
 
   calculateScore(issues) {
     let categoryScores = {
       'overall': 100,
     };
+
+    // Spåra vilka kategorier som ska nollas pga showstopper-regler
+    const zeroedCategories = new Set();
+
     issues.forEach(issue => {
       if (!categoryScores[issue.category]) {
         categoryScores[issue.category] = 100;
       }
+
+      // Showstopper-regler nollar kategorin direkt. Kolla att severity
+      // inte är 'resolved' — då är regeln visserligen med i listan men
+      // som godkänd, och ska inte trigga nollställning.
+      if (this.showstopperRules.has(issue.rule) && issue.severity !== 'resolved') {
+        zeroedCategories.add(issue.category);
+        return; // Hoppa över vanlig poängdragning för detta issue
+      }
+
       if (issue.severity === 'critical') {
         categoryScores[issue.category] -= 25;
       } else if (issue.severity === 'error') {
@@ -19,6 +46,12 @@ export class Score {
         categoryScores[issue.category] -= 1;
       }
     });
+
+    // Tvinga showstopper-kategorier till 0
+    zeroedCategories.forEach(category => {
+      categoryScores[category] = 0;
+    });
+
     const Scores = Object.entries(categoryScores)
       .filter(([key]) => key !== 'overall') // Exclude 'overall' from the calculation
       .map(([, value]) => value);


### PR DESCRIPTION
## Summary

Adds a mechanism for rules that represent fundamental, "you failed the
exam" failures to zero out their category score, instead of going
through the normal severity deduction.

## Motivation

The current scoring deducts 25 points for `severity: 'critical'`, which
means a site missing a legally required accessibility statement scores
75/100 (rating 3.75/5.0). That doesn't reflect the severity of the
underlying problem — a legally mandated artifact is entirely missing.

We can't simply make all `critical` issues zero out the category,
because the lighthouse converter also uses `severity: 'critical'` in
its try/catch fallback when an audit crashes. That's a technical
failure of one audit, not a wholesale failure of the category. So the
trigger must be a rule whitelist, not the severity field.

## Change

`Score` now holds a `showstopperRules` set. During `calculateScore`,
any issue whose rule is in the set, with a non-resolved severity,
forces its category score to 0. All other scoring behaviour is
unchanged.

Currently the set contains only `'no-a11y-statement'`. If we later
identify other fundamental failures (e.g. missing HTTPS, depending on
policy), they can be added here.

## Impact on other plugins

None. Verified by examining all uses of `severity: 'critical'` across
the plugin family:

- `lighthouse-converter.js` crash fallback uses `critical` but with
  audit-specific rule names — not in the showstopper set.
- `plugin-accessibility-statement` uses `critical` only for
  `no-a11y-statement`, which is the rule we explicitly want to flag.

## Verification

- `https://finsamornskoldsvik.se` (no statement): `score.a11y` goes
  from 75 → 0, `rating_a11y` is now lowest possible.
- `https://eskilstuna.se` ("delvis förenlig" statement): unchanged,
  `score.a11y: 90`.
- Lighthouse-driven tests: unchanged.

## Related

Fixes [<link to issue in Webperf-se/webperf_core>](https://github.com/Webperf-se/webperf_core/issues/1467)