### PR TITLE
feat: aggregate plugin-standard-files into webperf-core.json (2026.6.1)

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -43,6 +43,5 @@ jobs:
             Changes since ${{ steps.changes.outputs.last-tag }}:
             ${{ steps.changes.outputs.log }}
           assignees: 7h3Rabbit
-          reviewers: 7h3Rabbit
           add-paths: |
             package.json

--- a/lib/index.js
+++ b/lib/index.js
@@ -190,6 +190,10 @@ export default class WebPerfPlugin extends SitespeedioPlugin {
         await this.appendIssuesToData(message.data.knowledgeData);
         break;
       }
+      case 'webperf-plugin-standard-files.webPerfCoreSummary': {
+        await this.appendIssuesToData(message.data.knowledgeData);
+        break;
+      }
       case 'sitespeedio.summarize': {
         for (let group of Object.keys(this.data.groups)) {
           for (let url of Object.keys(this.data.groups[group].pages)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-webperf-core",
-  "version": "2026.6.0",
+  "version": "2026.6.1",
   "type": "module",
   "exports": "./lib/index.js",
   "publishConfig": {


### PR DESCRIPTION
## What

Adds the aggregation handler so the **plugin-standard-files** output flows into the consolidated `webperf-core.json` that `webperf_core` reads:

```
plugin-standard-files → plugin-webperf-core (this) → webperf_core
```

Without this, standard-files issues are emitted but never aggregated, so they'd never reach the report.

## Changes

- `lib/index.js`: handle `webperf-plugin-standard-files.webPerfCoreSummary` (same pattern as the other plugins).
- `package.json`: bump to `2026.6.1` — merging this triggers **Create Release** and publishes to npm.
- `prep-release.yml`: drop the `reviewers: 7h3Rabbit` line (not a collaborator → fails the Create-PR step). `assignees` stays.

## Note

This is the prerequisite for wiring `plugin-standard-files` into `webperf_core`. Equivalent to the unmerged `aggregate-standard-files` branch, minus an unintended eslint downgrade.

Merging publishes `2026.6.1`; then `webperf_core` can depend on it.